### PR TITLE
Hotfix: use system-provided cyrus-sasl/libsasl2 at runtime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,8 +25,7 @@ jobs:
       - name: Build and test
         run: |
           dotnet nuget add source  --username user --password ${{ github.token }} --store-password-in-clear-text --name github https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
-          dotnet restore
-          dotnet test -c Release test/Confluent.Kafka.UnitTests/Confluent.Kafka.UnitTests.csproj
+          dotnet test -c Release /p:TreatWarningsAsErrors=true test/Confluent.Kafka.UnitTests/Confluent.Kafka.UnitTests.csproj
 
   package:
     needs:  [build-test]
@@ -50,17 +49,22 @@ jobs:
       - name: Build and create packages
         run: |
           dotnet nuget add source  --username user --password ${{ github.token }} --store-password-in-clear-text --name github https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
-          dotnet restore
           dotnet build Confluent.Kafka.sln -c Release
 
           # Different packaging for tagged vs untagged builds
+          $proj_version = (dotnet msbuild ./src/Confluent.Kafka/Confluent.Kafka.csproj -getproperty:VersionPrefix)
           if ($env:GITHUB_REF -match '^refs/tags/') {
-            $suffix = "gr"
+            $tag_version = $env:GITHUB_REF -replace '^refs/tags/v', ''
+            if ($tag_version -ne $proj_version) {
+              Write-Output "::error title=Version mismatch::Tag version '$tag_version' does not match project version '$proj_version'."
+              exit 1
+            }
           } else {
-            $suffix = "ci-$env:GITHUB_RUN_ID"
+            $version_components = $proj_version -split '\+'
+            $version_args = @("/p:Version=$($version_components[0])-ci-$env:GITHUB_RUN_ID+$($version_components[1])")
           }
 
-          dotnet pack src/Confluent.Kafka/Confluent.Kafka.csproj --output dist -c Release --version-suffix $suffix 
+          dotnet pack src/Confluent.Kafka/Confluent.Kafka.csproj --output dist -c Release @version_args
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/src/Confluent.Kafka/Confluent.Kafka.csproj
+++ b/src/Confluent.Kafka/Confluent.Kafka.csproj
@@ -16,7 +16,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Title>Confluent.Kafka</Title>
     <AssemblyName>Confluent.Kafka</AssemblyName>
-    <VersionPrefix>2.11.0</VersionPrefix>
+    <VersionPrefix>2.11.0.1-RC1+gr</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net462;net6.0;net8.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Confluent.Kafka/Confluent.Kafka.csproj
+++ b/src/Confluent.Kafka/Confluent.Kafka.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="librdkafka.redist" Version="2.11.0-gr">
+    <PackageReference Include="librdkafka.redist" Version="2.11.0.1-RC1+gr">
       <PrivateAssets Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">None</PrivateAssets>
     </PackageReference>
   </ItemGroup>


### PR DESCRIPTION
- CI: improve version management
  - make sure that only the specific version of `librdkafka.redist` can be restored
  - make sure that the tag and project versions match
  - handle versions with build metadata
- Hotfix: use system-provided cyrus-sasl/libsasl2 at runtime (use `librdkafka.redist` version `2.11.0.1-RC1+gr`)
- Bump version to `2.11.0.1-RC1+gr`